### PR TITLE
Added rank updating to possible operations

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -17,6 +17,7 @@ SYNC_ADD = "add"
 SYNC_UPDATE = "update"
 SYNC_UPDATE_MATERIAL = "update_material"
 SYNC_DELETE = "delete"
+SYNC_UPDATE_RANK = "update_rank"
 
 SYNC_ACTION_ALLOW = "Allow"
 SYNC_ACTION_SKIP = "Skip"


### PR DESCRIPTION
This was a little tweak I made for myself that I thought I would push back upstream to see if you were interested in merging it in.

I've created an additional sync operation that will check to see if your rank on padherder is different from the rank captured with the data, and if so will issue a PATCH to the user profile to update.

I tried to mimic your code style as best I could and tested this with my NA and JP account.

If you don't like how I did this or it breaks something I didn't realize I can change it or you can reject it, no big deal.

Thanks 
